### PR TITLE
Wire the native file watcher (ROM hot-reload + config/bindings live-reload)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,13 @@ The rules below are the parts that don't fit those.
   can't resolve `react`. Don't bump any submodule pointer (in either repo) without
   checking — they're managed deliberately. RetroPlug also keeps `deps/sameboy` +
   `deps/mesen` / `deps/r8brain` / `deps/enkiTS` (the shared core), and `deps/efsw`
-  (the file-watcher is *designed* to use it — `drainChangedPaths` is a stub
-  today, so nothing links it yet). `deps/catch2` is the C++ unit-test framework:
+  (the file-watcher — `NativeFileWatcher` behind `HostRpcService::drainChangedPaths`
+  — now uses it: `add_subdirectory`'d `EXCLUDE_FROM_ALL` at the root, `efsw-static`
+  linked into `retroplug-backend`; the watcher is opt-in via `enableWatching`, which
+  only the plugin calls). `deps/catch2` is the C++ unit-test framework:
   it's `add_subdirectory`'d at the root (`EXCLUDE_FROM_ALL`) and linked by the
   `test:plugin` binaries (`retroplug-plugin-test` / `retroplug-classid-test` /
-  `retroplug-audio-test`) as `Catch2::Catch2WithMain`.
+  `retroplug-audio-test` / `retroplug-watcher-test`) as `Catch2::Catch2WithMain`.
 - **`deps/sameboy` is patched at configure — a dirty working tree there is
   EXPECTED, not stray changes.** The per-channel (4-stem) Game Boy audio tap lives
   in `Core/apu.{c,h}` and ships as a tracked patch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,13 @@ add_subdirectory(deps/enkiTS)
 add_library(miniaudio INTERFACE)
 target_include_directories(miniaudio INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/deps/miniaudio)
 
+# --- efsw: cross-platform filesystem watcher backing the native file watcher
+# (NativeFileWatcher → HostRpcService::drainChangedPaths, spec/07). EXCLUDE_FROM_ALL so only the
+# static lib the plugin links (efsw-static) compiles — a build that never links it pays nothing.
+# efsw's own CMake links Threads::Threads to the shared lib only, so consumers of efsw-static add it
+# themselves (done on retroplug-backend). BUILD_TEST_APP / EFSW_INSTALL default OFF as a subproject.
+add_subdirectory(deps/efsw "${CMAKE_BINARY_DIR}/deps/efsw" EXCLUDE_FROM_ALL)
+
 # lvgl-js-native + the framework PIC settings now come from dpf.js (above).
 
 # --- mgb-rom: the mGB Game Boy MIDI-synth ROM, embedded in the binary ---------

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "node scripts/cmake-build.js tjs-cli && node packages/retroplug/scripts/run-tests.mjs",
     "test:native": "node scripts/cmake-build.js retroplug-host && node packages/retroplug/scripts/run-native-tests.mjs",
     "test:ui": "node scripts/cmake-build.js retroplug-ui-test && node packages/retroplug/scripts/run-ui-tests.mjs",
-    "test:plugin": "node scripts/cmake-build.js retroplug-plugin-test retroplug-classid-test retroplug-audio-test && node packages/retroplug/scripts/run-plugin-tests.mjs",
+    "test:plugin": "node scripts/cmake-build.js retroplug-plugin-test retroplug-classid-test retroplug-audio-test retroplug-watcher-test && node packages/retroplug/scripts/run-plugin-tests.mjs",
     "screenshot": "node scripts/cmake-build.js retroplug-jack && tools/run-standalone.sh",
     "profile": "tools/run-profile.sh stats",
     "validate": "node scripts/cmake-build.js retroplug-clap retroplug-vst3 && tools/validate-plugins.sh",

--- a/packages/native/CMakeLists.txt
+++ b/packages/native/CMakeLists.txt
@@ -75,7 +75,8 @@ set_target_properties(retroplug-core PROPERTIES
 # entry point, so both the test host (retroplug-host) and the DPF plugin compose the SAME
 # Engine/Backend/DspRuntime. Includes + links are PUBLIC so consumers inherit them.
 add_library(retroplug-backend STATIC
-    src/host/rpc/HostRpcService.cpp         # fs / config / zip (pure, stateless)
+    src/host/rpc/HostRpcService.cpp         # fs / config / zip (+ opt-in efsw file watcher)
+    src/host/rpc/NativeFileWatcher.cpp      # efsw watcher behind drainChangedPaths / setWatchedRoms
     src/host/rpc/EngineRpcService.cpp       # emulator surface over Engine + Invoker + Factory
     src/host/rpc/DebugRpcService.cpp        # live-core inspection over Engine (CLI-only facet)
     src/host/rpc/AudioDriverRpcService.cpp  # background audio thread + observation atomics
@@ -102,9 +103,13 @@ target_include_directories(retroplug-backend PUBLIC
     #  miniz header dir, arrive PUBLIC from retroplug-core above.)
 )
 
+find_package(Threads REQUIRED)  # efsw-static needs pthreads on Linux (its CMake links it to the shared lib only)
+
 target_link_libraries(retroplug-backend PUBLIC
     retroplug-core      # Project + SystemBase + SameBoy/Mesen; PUBLIC-brings rpcpp + miniz
     tjs                 # txiki.js/QuickJS runtime (transitively brings qjs + libuv)
+    efsw-static         # NativeFileWatcher's filesystem watcher (PUBLIC-brings efsw/efsw.hpp include dir)
+    Threads::Threads
 )
 
 set_target_properties(retroplug-backend PROPERTIES
@@ -515,6 +520,21 @@ target_compile_definitions(retroplug-audio-test PRIVATE
     RP_N8_MIDI_ROM_PATH="${CMAKE_SOURCE_DIR}/resources/roms/n8-midi.nes")
 
 set_target_properties(retroplug-audio-test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+# retroplug-watcher-test guards the native file watcher (NativeFileWatcher over efsw): config.json +
+# bindings/ recursive detection, registered-ROM parent-dir watches, and the unregistered-file filter.
+# Links retroplug-backend (which PUBLIC-brings NativeFileWatcher + efsw-static). Also `pnpm test:plugin`.
+add_executable(retroplug-watcher-test EXCLUDE_FROM_ALL
+    test/watcher/NativeFileWatcher.test.cpp)
+
+target_link_libraries(retroplug-watcher-test PRIVATE
+    retroplug-backend          # NativeFileWatcher + efsw-static
+    Catch2::Catch2WithMain)
+
+set_target_properties(retroplug-watcher-test PROPERTIES
     CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")

--- a/packages/native/plugin/PluginDSP.cpp
+++ b/packages/native/plugin/PluginDSP.cpp
@@ -240,6 +240,11 @@ private:
         // Publish the host so an editor can attach its LVGL display to this same context.
         shared_.host = &host_;
 
+        // Turn on the native file watcher (config.json + bindings/ recursively; ROMs registered by TS via
+        // setWatchedRoms). The TS FileWatcher.pump() drains it from the UI idle loop (__rp_pumpWatcher).
+        // Only the plugin enables this — the test host / CLI leave drainChangedPaths inert.
+        hostSvc_.enableWatching(hostSvc_.configDir());
+
         // Headless seed: reaper -renderproject sets RETROPLUG_AUTOLOAD_PROJECT to a .rplg path.
         if (const char* autoload = std::getenv("RETROPLUG_AUTOLOAD_PROJECT")) {
             const std::string ok = callGlobal("__rp_loadProjectPath", autoload);

--- a/packages/native/plugin/PluginUI.cpp
+++ b/packages/native/plugin/PluginUI.cpp
@@ -79,6 +79,7 @@ class PluginUI : public UI {
     std::chrono::steady_clock::time_point screenshotLast_{};
     bool windowTitleSet_ = false;
     bool allowClose_ = false; // set by requestQuit() so the re-entrant onClose() lets the window close
+    unsigned watcherPumpTick_ = 0; // throttles the file-watcher pump in uiIdle (efsw already coalesced)
 
     // Window geometry: the resize-grip fallback + tiling-WM clamp detection. Once a size comes back
     // different from what we asked (a Wayland/Hyprland tile), wmControlled_ latches true and we stop
@@ -406,6 +407,18 @@ protected:
         if (JSContext* ctx = jsEngine.getContext()) {
             jsEngine.emit("frame", 0, nullptr); // drives EmulatorTile's getFrame
             pumpGamepad(ctx);                   // poll controllers → the gamepad-* JS bus
+            // File watcher: drain native's changed paths + react (config live-reload / bindings refresh /
+            // ROM hot-reload). efsw already coalesced the changes on its own thread, so a low cadence (~1/15
+            // frames, a few Hz) is plenty and keeps stat/JS churn off the hot path. Inert if the control
+            // plane didn't define the hook (older bundle / headless).
+            if ((++watcherPumpTick_ % 15) == 0 && hasGlobalFunction(ctx, "__rp_pumpWatcher")) {
+                JSValue global = JS_GetGlobalObject(ctx);
+                JSValue fn     = JS_GetPropertyStr(ctx, global, "__rp_pumpWatcher");
+                JSValue ret    = JS_Call(ctx, fn, JS_UNDEFINED, 0, nullptr);
+                JS_FreeValue(ctx, ret);
+                JS_FreeValue(ctx, fn);
+                JS_FreeValue(ctx, global);
+            }
         }
         jsEngine.tick();                                               // pump the shared host's JS loop
         maybeWriteScreenshot();

--- a/packages/native/src/host/rpc/BackendRpcRegistration.hpp
+++ b/packages/native/src/host/rpc/BackendRpcRegistration.hpp
@@ -11,7 +11,7 @@
 #include "host/rpc/EngineRpcService.hpp"
 #include "host/rpc/HostRpcService.hpp"
 
-// --- host: filesystem / config / codec (16) ---
+// --- host: filesystem / config / codec (17) ---
 template <class Server>
 void registerHostRpc(Server& s, HostRpcService& h) {
     s.template addMethod<&HostRpcService::readFile>(h);
@@ -24,6 +24,7 @@ void registerHostRpc(Server& s, HostRpcService& h) {
     s.template addMethod<&HostRpcService::listDir>(h);
     s.template addMethod<&HostRpcService::deleteFile>(h);
     s.template addMethod<&HostRpcService::drainChangedPaths>(h);
+    s.template addMethod<&HostRpcService::setWatchedRoms>(h);
     s.template addMethod<&HostRpcService::canonicalize>(h);
     s.template addMethod<&HostRpcService::readFilePrefix>(h);
     s.template addMethod<&HostRpcService::configDir>(h);
@@ -114,7 +115,7 @@ void registerDriverRpc(Server& s, AudioDriverRpcService& d) {
     s.template addMethod<&AudioDriverRpcService::drainReleased>(d);
 }
 
-// The full union (69 methods) + discovery — every facet mounted. Hosts that expose the whole surface
+// The full union (70 methods) + discovery — every facet mounted. Hosts that expose the whole surface
 // (the CLI + test host) use this; scoped hosts call the individual register functions they're allowed to.
 template <class Server>
 void registerAllBackendRpc(Server& s, HostRpcService& host, EngineRpcService& engine,

--- a/packages/native/src/host/rpc/HostRpcService.cpp
+++ b/packages/native/src/host/rpc/HostRpcService.cpp
@@ -9,6 +9,7 @@
 #include <system_error>
 
 #include "Version.hpp"
+#include "host/rpc/NativeFileWatcher.hpp"
 #include "util/MinizZip.hpp"
 
 namespace fs = std::filesystem;
@@ -63,6 +64,11 @@ std::size_t fileSizeOr(const std::string& path, std::size_t fallback) {
 }
 
 } // namespace
+
+// Out-of-line so the unique_ptr<NativeFileWatcher> member sees the complete type (it's forward-declared
+// in the header to keep efsw out of every HostRpcService includer).
+HostRpcService::HostRpcService() = default;
+HostRpcService::~HostRpcService() = default;
 
 std::optional<rfl::Bytestring> HostRpcService::readFile(std::string path) {
     auto bytes = slurp(path, fileSizeOr(path, 0));
@@ -153,7 +159,18 @@ bool HostRpcService::deleteFile(std::string path) {
 }
 
 std::vector<std::string> HostRpcService::drainChangedPaths() {
-    return {};
+    return watcher_ ? watcher_->drainChangedPaths() : std::vector<std::string>{};
+}
+
+bool HostRpcService::setWatchedRoms(std::vector<std::string> paths) {
+    if (!watcher_) return false;
+    watcher_->setWatchedRoms(paths);
+    return true;
+}
+
+void HostRpcService::enableWatching(std::string configDir) {
+    if (watcher_) return;  // idempotent
+    watcher_ = std::make_unique<NativeFileWatcher>(std::move(configDir));
 }
 
 std::string HostRpcService::canonicalize(std::string path) {

--- a/packages/native/src/host/rpc/HostRpcService.hpp
+++ b/packages/native/src/host/rpc/HostRpcService.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
@@ -9,11 +10,17 @@
 
 #include "host/rpc/BackendTypes.hpp"
 
+class NativeFileWatcher;
+
 // The fs / config / codec half of the Backend: std::filesystem + miniz + config-dir
-// resolution + LSDJ sav authoring. Pure and stateless — no Engine, no threads — so it's reusable
-// verbatim across hosts.
+// resolution + LSDJ sav authoring. Stateless and thread-free by default — reusable verbatim across
+// hosts — UNLESS a host calls enableWatching(), which spins up an efsw NativeFileWatcher so
+// drainChangedPaths / setWatchedRoms become live (the plugin does this; the test host + CLI don't).
 class HostRpcService {
 public:
+    HostRpcService();
+    ~HostRpcService();
+
     // --- filesystem ---
     std::optional<rfl::Bytestring> readFile(std::string path);
     bool writeFile(std::string path, rfl::Bytestring bytes);
@@ -28,7 +35,11 @@ public:
     bool rename(std::string from, std::string to);
     std::vector<std::string> listDir(std::string dir);
     bool deleteFile(std::string path);
-    std::vector<std::string> drainChangedPaths();  // no watcher yet — always empty
+    // The native side of the file watcher (spec/07). drainChangedPaths pulls the paths the efsw watcher
+    // saw since the last call (empty when watching isn't enabled); setWatchedRoms tells it which ROM
+    // files to watch (their parent dirs), recomputed by TS whenever the systems list changes.
+    std::vector<std::string> drainChangedPaths();
+    bool setWatchedRoms(std::vector<std::string> paths);
 
     // --- paths / config ---
     std::string canonicalize(std::string path);
@@ -39,4 +50,11 @@ public:
     // --- codec (miniz) ---
     rfl::Bytestring zip(std::vector<BackendZipInput> entries);
     std::vector<BackendZipEntry> unzip(rfl::Bytestring bytes);
+
+    // Host opt-in: start the efsw watcher over `configDir` (config.json + bindings/). Idempotent —
+    // a second call is ignored. Until called, drainChangedPaths returns {} and setWatchedRoms no-ops.
+    void enableWatching(std::string configDir);
+
+private:
+    std::unique_ptr<NativeFileWatcher> watcher_;  // null unless enableWatching() ran
 };

--- a/packages/native/src/host/rpc/NativeFileWatcher.cpp
+++ b/packages/native/src/host/rpc/NativeFileWatcher.cpp
@@ -1,0 +1,93 @@
+#include "host/rpc/NativeFileWatcher.hpp"
+
+#include <filesystem>
+#include <system_error>
+#include <utility>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// weakly_canonical resolves symlinks/.. without requiring the target to exist (a Delete event names a
+// path that's already gone), so watcher events and setWatchedRoms register the same string TS will.
+std::string canon(const fs::path& p) {
+    std::error_code ec;
+    const fs::path c = fs::weakly_canonical(p, ec);
+    return (ec ? p : c).string();
+}
+
+} // namespace
+
+NativeFileWatcher::NativeFileWatcher(std::string configDir) {
+    if (!configDir.empty()) {
+        configDir_   = canon(configDir);
+        bindingsDir_ = canon(fs::path(configDir_) / "bindings");
+        // Recursive so config.json and every bindings/<profile>.json land in one watch. A bad path
+        // returns an error WatchID (< 0) — harmless, ROM watches still function.
+        watcher_.addWatch(configDir_, this, /*recursive*/ true);
+    }
+    watcher_.watch();  // starts the background thread; add/removeWatch are safe afterwards
+}
+
+void NativeFileWatcher::setWatchedRoms(const std::vector<std::string>& paths) {
+    std::unordered_set<std::string>          roms;   // canonical ROM paths
+    std::unordered_map<std::string, int>     wanted; // canonical parent dir -> refcount (value unused)
+    roms.reserve(paths.size());
+    for (const auto& p : paths) {
+        if (p.empty()) continue;
+        const std::string c = canon(p);
+        roms.insert(c);
+        wanted.emplace(fs::path(c).parent_path().string(), 0);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        watchedRoms_ = std::move(roms);
+    }
+
+    // Reconcile the per-parent-dir watches (UI-thread-only bookkeeping). Drop dirs no longer referenced,
+    // add newly-needed ones. Dirs inside the recursively-watched config tree double-fire harmlessly (TS
+    // dedups), so we don't special-case them.
+    for (auto it = romDirs_.begin(); it != romDirs_.end();) {
+        if (!wanted.count(it->first)) {
+            watcher_.removeWatch(it->second);
+            it = romDirs_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    for (const auto& [dir, _] : wanted) {
+        if (dir.empty() || romDirs_.count(dir)) continue;
+        const efsw::WatchID id = watcher_.addWatch(dir, this, /*recursive*/ false);
+        if (id >= 0) romDirs_.emplace(dir, id);  // a non-existent dir returns an error id — skip it
+    }
+}
+
+std::vector<std::string> NativeFileWatcher::drainChangedPaths() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::string> out;
+    out.swap(changed_);
+    return out;
+}
+
+void NativeFileWatcher::handleFileAction(efsw::WatchID /*watchid*/, const std::string& dir,
+                                         const std::string& filename, efsw::Action /*action*/,
+                                         const std::string& /*oldFilename*/) {
+    const std::string full = canon(fs::path(dir) / filename);
+    const fs::path    fp(full);
+    const std::string parent = fp.parent_path().string();
+
+    bool relevant = false;
+    if (!configDir_.empty() && parent == configDir_ && filename == "config.json") {
+        relevant = true;  // the user config
+    } else if (!bindingsDir_.empty() && parent == bindingsDir_ && fp.extension() == ".json") {
+        relevant = true;  // a bindings profile
+    } else {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (watchedRoms_.count(full)) relevant = true;  // a watched ROM
+    }
+    if (!relevant) return;
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    changed_.push_back(full);
+}

--- a/packages/native/src/host/rpc/NativeFileWatcher.hpp
+++ b/packages/native/src/host/rpc/NativeFileWatcher.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+// NativeFileWatcher — the C++ half of "watcher = C++, policy = TS" (doc-03 / spec/07).
+//
+// It owns an efsw file watcher and reports changed paths that the TS FileWatcher.pump() drains via
+// HostRpcService::drainChangedPaths(): the user config, bindings profiles, and any watched ROM. It
+// makes NO policy decisions — TS decides what a change means (reload config, refresh bindings, cold-boot
+// a system with reloadOnRomChange on).
+//
+// efsw watches *directories*, so a single recursive watch on the config dir covers config.json +
+// bindings/*.json, and each ROM is covered by watching its parent directory and filtering events to the
+// registered basename. Any efsw action (Add/Delete/Modified/Moved) on a watched target counts as a
+// change — that also catches save-by-rename editors.
+//
+// Threading: efsw delivers handleFileAction on its own background thread; setWatchedRoms + drain run on
+// the UI thread. A single mutex guards the two pieces of cross-thread state (the changed-paths buffer and
+// the watched-ROM filter set). The dir→watchid bookkeeping is UI-thread-only.
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <efsw/efsw.hpp>
+
+class NativeFileWatcher final : public efsw::FileWatchListener {
+public:
+    // Starts watching `configDir` (recursively — config.json + bindings/) immediately. A missing /
+    // unresolvable dir is tolerated: ROM watches still work and config events simply never fire.
+    explicit NativeFileWatcher(std::string configDir);
+    ~NativeFileWatcher() override = default;
+
+    // UI thread. Replace the set of ROM files to watch. Reconciles the per-parent-dir efsw watches
+    // (adds newly-needed dirs, drops ones no longer referenced) and swaps the basename filter set.
+    void setWatchedRoms(const std::vector<std::string>& paths);
+
+    // UI thread. Pull + clear every changed path seen since the last drain (deduped downstream in TS).
+    std::vector<std::string> drainChangedPaths();
+
+    // efsw watcher thread. Never call directly.
+    void handleFileAction(efsw::WatchID watchid, const std::string& dir, const std::string& filename,
+                          efsw::Action action, const std::string& oldFilename) override;
+
+private:
+    std::string configDir_;    // canonical; "" if unresolved
+    std::string bindingsDir_;  // canonical configDir/bindings; "" if configDir_ is ""
+
+    std::mutex                        mutex_;         // guards changed_ + watchedRoms_
+    std::vector<std::string>          changed_;       // pending changes for the next drain
+    std::unordered_set<std::string>   watchedRoms_;   // canonical ROM paths the listener filters against
+
+    // UI-thread-only: canonical parent dir → its efsw watch id, for reconcile in setWatchedRoms.
+    std::unordered_map<std::string, efsw::WatchID> romDirs_;
+
+    // MUST be the last member: its destructor joins the efsw watcher thread, which calls
+    // handleFileAction (touching mutex_ + changed_ + watchedRoms_). Declared last → destroyed FIRST, so
+    // the thread is gone before those members are torn down (else a late callback is a use-after-free).
+    efsw::FileWatcher watcher_;
+};

--- a/packages/native/test/sanitizer/tsan.supp
+++ b/packages/native/test/sanitizer/tsan.supp
@@ -14,3 +14,12 @@
 # Any real race elsewhere still surfaces; these only cover the readInto memcpy.
 race:MemorySnapshotTriple::readInto
 race:FrameBufferTriple::readInto
+
+# efsw (vendored, deps/efsw) internal teardown race: FileWatcherInotify's destructor
+# reads a status flag that its own watcher thread writes in handleAction as the thread
+# winds down, without full synchronization. BOTH racing frames are efsw-internal — our
+# NativeFileWatcher (which joins the thread via the efsw destructor, correctly ordered
+# after our own members) is not in either access. Upstream code we don't own; benign on
+# teardown. Scoped to the two named efsw functions so real races elsewhere still surface.
+race:efsw::FileWatcherInotify::~FileWatcherInotify
+race:efsw::FileWatcherInotify::handleAction

--- a/packages/native/test/watcher/NativeFileWatcher.test.cpp
+++ b/packages/native/test/watcher/NativeFileWatcher.test.cpp
@@ -1,0 +1,150 @@
+// NativeFileWatcher — the efsw mechanism behind HostRpcService::drainChangedPaths (spec/07). Verifies
+// it reports config.json + bindings/*.json (recursive config-dir watch) and registered ROMs (parent-dir
+// watch, filtered by path), and that unregistered files under the config dir are ignored.
+//
+// efsw delivers on a background thread with real filesystem latency, so every assertion polls
+// drainChangedPaths() with a deadline rather than reading once.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <unordered_set>
+
+#include "host/rpc/HostRpcService.hpp"
+#include "host/rpc/NativeFileWatcher.hpp"
+
+namespace fs = std::filesystem;
+using namespace std::chrono_literals;
+
+namespace {
+
+fs::path canon(const fs::path& p) {
+    std::error_code ec;
+    const fs::path c = fs::weakly_canonical(p, ec);
+    return ec ? p : c;
+}
+
+void writeFile(const fs::path& p, const std::string& text) {
+    std::ofstream(p, std::ios::binary | std::ios::trunc) << text;
+}
+
+// A unique scratch dir under temp (no Math.random in this env, so derive from the steady clock).
+fs::path makeTempDir() {
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    fs::path dir = fs::temp_directory_path() / ("rp-watcher-" + std::to_string(stamp));
+    fs::create_directories(dir);
+    return dir;
+}
+
+// Poll drainChangedPaths, accumulating everything seen, until `want` (canonical) shows up or the
+// deadline passes. Returns true if it arrived.
+bool waitFor(NativeFileWatcher& w, const fs::path& want, std::chrono::milliseconds timeout = 5s) {
+    const std::string target = canon(want).string();
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    std::unordered_set<std::string> seen;
+    while (std::chrono::steady_clock::now() < deadline) {
+        for (auto& p : w.drainChangedPaths()) seen.insert(canon(p).string());
+        if (seen.count(target)) return true;
+        std::this_thread::sleep_for(25ms);
+    }
+    return false;
+}
+
+// Drain for a fixed window and report whether `unwanted` (canonical) ever appeared.
+bool sawWithin(NativeFileWatcher& w, const fs::path& unwanted, std::chrono::milliseconds window = 1s) {
+    const std::string target = canon(unwanted).string();
+    const auto deadline = std::chrono::steady_clock::now() + window;
+    while (std::chrono::steady_clock::now() < deadline) {
+        for (auto& p : w.drainChangedPaths())
+            if (canon(p).string() == target) return true;
+        std::this_thread::sleep_for(25ms);
+    }
+    return false;
+}
+
+} // namespace
+
+TEST_CASE("NativeFileWatcher reports config.json and bindings profiles", "[watcher]") {
+    const fs::path dir = makeTempDir();
+    fs::create_directories(dir / "bindings");  // exists before the watcher so the recursive watch covers it
+
+    NativeFileWatcher w(dir.string());
+    std::this_thread::sleep_for(100ms);  // let the watch thread arm
+
+    writeFile(dir / "config.json", "{}");
+    CHECK(waitFor(w, dir / "config.json"));
+
+    writeFile(dir / "bindings" / "wasd.json", "{}");
+    CHECK(waitFor(w, dir / "bindings" / "wasd.json"));
+
+    // An unrelated file under the config dir is watched by efsw but filtered out by the watcher.
+    writeFile(dir / "recent.json", "[]");
+    CHECK_FALSE(sawWithin(w, dir / "recent.json"));
+
+    fs::remove_all(dir);
+}
+
+TEST_CASE("NativeFileWatcher reports a registered ROM change, ignores an unregistered sibling", "[watcher]") {
+    const fs::path cfg  = makeTempDir();
+    const fs::path roms = makeTempDir();
+    writeFile(roms / "game.gb", "rom-v1");
+    writeFile(roms / "other.gb", "rom-v1");
+
+    NativeFileWatcher w(cfg.string());
+    w.setWatchedRoms({(roms / "game.gb").string()});
+    std::this_thread::sleep_for(100ms);
+
+    writeFile(roms / "game.gb", "rom-v2");         // registered → reported
+    CHECK(waitFor(w, roms / "game.gb"));
+
+    writeFile(roms / "other.gb", "rom-v2");        // same dir, not registered → ignored
+    CHECK_FALSE(sawWithin(w, roms / "other.gb"));
+
+    // Unregistering stops the reports.
+    w.setWatchedRoms({});
+    std::this_thread::sleep_for(100ms);
+    (void)w.drainChangedPaths();
+    writeFile(roms / "game.gb", "rom-v3");
+    CHECK_FALSE(sawWithin(w, roms / "game.gb"));
+
+    fs::remove_all(cfg);
+    fs::remove_all(roms);
+}
+
+// The HostRpcService facade the plugin actually uses: enableWatching() spins up the watcher, and
+// drainChangedPaths / setWatchedRoms delegate to it. Before enableWatching they're inert (matching the
+// test host / CLI, which never enable watching), so this also pins the opt-in contract.
+TEST_CASE("HostRpcService gates the watcher behind enableWatching", "[watcher]") {
+    const fs::path cfg  = makeTempDir();
+    const fs::path roms = makeTempDir();
+    writeFile(roms / "game.gb", "rom-v1");
+
+    HostRpcService svc;
+    // Inert until enabled.
+    CHECK(svc.drainChangedPaths().empty());
+    CHECK_FALSE(svc.setWatchedRoms({(roms / "game.gb").string()}));
+
+    svc.enableWatching(cfg.string());
+    CHECK(svc.setWatchedRoms({(roms / "game.gb").string()}));
+    std::this_thread::sleep_for(100ms);
+
+    writeFile(roms / "game.gb", "rom-v2");
+    writeFile(cfg / "config.json", "{}");
+
+    const std::string wantRom = canon(roms / "game.gb").string();
+    const std::string wantCfg = canon(cfg / "config.json").string();
+    std::unordered_set<std::string> seen;
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline && !(seen.count(wantRom) && seen.count(wantCfg))) {
+        for (auto& p : svc.drainChangedPaths()) seen.insert(canon(p).string());
+        std::this_thread::sleep_for(25ms);
+    }
+    CHECK(seen.count(wantRom));
+    CHECK(seen.count(wantCfg));
+
+    fs::remove_all(cfg);
+    fs::remove_all(roms);
+}

--- a/packages/retroplug/scripts/run-plugin-tests.mjs
+++ b/packages/retroplug/scripts/run-plugin-tests.mjs
@@ -2,7 +2,8 @@
 // Plugin unit-test runner. Runs the Catch2 C++ test binaries in sequence:
 // the per-context window-hook routing (retroplug-plugin-test), the class-id
 // counter sync that keeps the DAW-hosted editor from rendering blank
-// (retroplug-classid-test), and the per-channel audio taps (retroplug-audio-test).
+// (retroplug-classid-test), the per-channel audio taps (retroplug-audio-test),
+// and the native file watcher (retroplug-watcher-test).
 //
 // A tiny runner (rather than chaining `build/bin/foo && …` in package.json) so
 // the suite is cross-platform: it appends `.exe` on Windows and spawns each
@@ -20,7 +21,7 @@ const REPO = resolve(PKG, "../..");
 const BIN_DIR = process.env.RETROPLUG_BIN_DIR || join(REPO, "build", "bin");
 const EXE = process.platform === "win32" ? ".exe" : "";
 
-const BINARIES = ["retroplug-plugin-test", "retroplug-classid-test", "retroplug-audio-test"];
+const BINARIES = ["retroplug-plugin-test", "retroplug-classid-test", "retroplug-audio-test", "retroplug-watcher-test"];
 
 const filter = process.argv[2];
 const selected = filter ? BINARIES.filter((b) => b.includes(filter)) : BINARIES;

--- a/packages/retroplug/src/backend.ts
+++ b/packages/retroplug/src/backend.ts
@@ -56,11 +56,17 @@ export interface Backend {
   deleteFile(path: string): boolean;
 
   /** The watched-file paths that changed since the last drain (empty when nothing did).
-   *  Native owns the watching — efsw over the config dir + `bindings/`, plus the per-ROM
-   *  mtime poll — and collects the changed paths; TS pulls + reacts at idle (re-read
-   *  config, refresh bindings, reload a system whose ROM changed). A pull-drain, so the
-   *  sync Backend stays sync. */
+   *  Native owns the watching — efsw over the config dir + `bindings/` (recursive) and over
+   *  each watched ROM's parent directory — and collects the changed paths; TS pulls + reacts
+   *  at idle (re-read config, refresh bindings, reload a system whose ROM changed). A
+   *  pull-drain, so the sync Backend stays sync. */
   drainChangedPaths(): string[];
+
+  /** Tell native which ROM files to watch for changes (their parent dirs are watched, events
+   *  filtered to these paths). Policy lives in TS: recompute + call this whenever the systems
+   *  list changes; the config dir + `bindings/` are always watched and need no registration.
+   *  A no-op until a host enables watching (the plugin does; the test host / CLI don't). */
+  setWatchedRoms(paths: string[]): void;
 
   // --- Paths (the OS-specific bits TS can't reproduce) --------------------
 
@@ -295,7 +301,7 @@ export interface Backend {
 export type HostBackend = Pick<
   Backend,
   | "readFile" | "writeFile" | "writeFileAtomic" | "appendFile" | "writeFileAt" | "fileExists" | "rename" | "listDir" | "deleteFile"
-  | "drainChangedPaths" | "canonicalize" | "readFilePrefix" | "configDir" | "version"
+  | "drainChangedPaths" | "setWatchedRoms" | "canonicalize" | "readFilePrefix" | "configDir" | "version"
   | "zip" | "unzip" | "savFromJson" | "openFileBrowser"
 >;
 

--- a/packages/retroplug/src/pluginControlPlane.ts
+++ b/packages/retroplug/src/pluginControlPlane.ts
@@ -15,6 +15,7 @@
 import { composeAppStores, type StoreChannel, type AppStores } from "./appStores";
 import { createDspRuntime } from "./dspRuntime";
 import { syncDspFromStore } from "./appHost";
+import { FileWatcher } from "./fileWatcher";
 import { LsdjSyncMode } from "./settingsEnums";
 
 declare const __DSP_KERNEL_BUNDLE__: string;
@@ -77,8 +78,21 @@ const kernelOk = dsp.loadKernel(dsp.compileScript(__DSP_KERNEL_BUNDLE__)!);
 // re-renders the editor. composeAppStores already routed onChange / onFocusChange to the UI notify;
 // layer the DSP projection onto the structure signal without dropping that notify (focus changes, wired
 // to onFocusChange, re-render only — no DSP re-project).
+// The file watcher's TS policy half: drains native's changed paths and reacts (reload config, refresh
+// bindings, cold-boot a ROM-changed system with reloadOnRomChange on). A bindings change re-renders the
+// editor via the "bindings" notify. Driven from the UI idle loop through __rp_pumpWatcher below.
+const fileWatcher = new FileWatcher(stores.backend, stores.userConfig, project.systems, () => uiNotify.fn("bindings"));
+
+// Register the set of ROM files native should watch. Recomputed on every structural systems edit (the
+// list, and thus which ROMs exist, only changes there). Native always watches config.json + bindings/.
+const refreshWatchedRoms = (): void => {
+  const roms = project.systems.view().map((s) => s.romPath).filter((p): p is string => !!p);
+  stores.backend.setWatchedRoms(roms);
+};
+
 project.setOnSystemsChange(() => {
   syncDspFromStore(project, dsp);
+  refreshWatchedRoms();
   uiNotify.fn("systems");
 });
 
@@ -112,6 +126,12 @@ g.__rp_saveProjectB64 = (): string => {
 };
 
 g.__rp_newProject = (): void => project.newProject();
+
+// Drive the file watcher from the UI idle loop (PluginUI::uiIdle, throttled). Drains native's changed
+// paths and reacts; a no-op when nothing changed. Returns void — the host ignores the result.
+g.__rp_pumpWatcher = (): void => {
+  fileWatcher.pump();
+};
 
 // LSDj in a host-clocked sync mode (MidiSync / MidiSyncArduinoboy) locks its playback a fixed distance
 // behind the DAW clock — an emulator clock→sound latency, not a drift. Reporting it as plugin latency lets

--- a/packages/retroplug/src/realBackend.ts
+++ b/packages/retroplug/src/realBackend.ts
@@ -108,6 +108,7 @@ export function createHostClient(): HostBackend {
     listDir: (dir) => call("listDir", dir) as string[],
     deleteFile: (path) => call("deleteFile", path) as boolean,
     drainChangedPaths: () => call("drainChangedPaths") as string[],
+    setWatchedRoms: (paths) => void call("setWatchedRoms", paths),
     canonicalize: (path) => call("canonicalize", path) as string,
     readFilePrefix: (path, length) => bytesOrNull(call("readFilePrefix", path, length)),
     configDir: () => call("configDir") as string,

--- a/packages/retroplug/test-native/author-ext-rom-rplg.ts
+++ b/packages/retroplug/test-native/author-ext-rom-rplg.ts
@@ -1,0 +1,24 @@
+// Author a THIN `.rplg` (raw JSON, paths only) with a single GB system loaded from an EXTERNAL ROM path
+// and reloadOnRomChange ON — the fixture the file-watcher ROM-hot-reload verification autoloads. Unlike
+// author-mgb-rplg (embedded mGB → zip), this points at an on-disk ROM so overwriting that file triggers
+// the watcher. Driven by an esbuild wrapper that injects __ROM_PATH__ / __RPLG_OUT__.
+import { createRealBackend } from "../src/realBackend";
+import { RecentStore } from "../src/recentStore";
+import { ProjectStore } from "../src/projectStore";
+import { buildAppRegistry } from "../src/appHost";
+
+declare const __ROM_PATH__: string;
+declare const __RPLG_OUT__: string;
+
+const be = createRealBackend();
+const project = new ProjectStore(be, new RecentStore(be), buildAppRegistry());
+const id = project.systems.addSystem(__ROM_PATH__);
+if (id == null) {
+  console.log(`[author-ext-rom-rplg] FAILED to add system from ${__ROM_PATH__}`);
+  (globalThis as { tjs: { exit(code: number): void } }).tjs.exit(1);
+}
+project.systems.setReloadOnRomChange(id as number, true);
+const ok = project.save(__RPLG_OUT__);
+console.log(`[author-ext-rom-rplg] ${ok ? "wrote" : "FAILED"} ${__RPLG_OUT__} (system ${id})`);
+
+(globalThis as { tjs: { exit(code: number): void } }).tjs.exit(ok ? 0 : 1);

--- a/packages/retroplug/testing/mockBackend.ts
+++ b/packages/retroplug/testing/mockBackend.ts
@@ -80,8 +80,10 @@ export class MockBackend implements Backend {
   private sramOverrides = new Map<number, Uint8Array>();
 
   /** Paths queued by emitFileChange, drained by drainChangedPaths — simulates the
-   *  native watcher (efsw + ROM mtime poll) firing. */
+   *  native watcher (efsw) firing. */
   private changedPaths: string[] = [];
+  /** The last ROM set passed to setWatchedRoms — for tests asserting the policy wiring. */
+  watchedRoms: string[] = [];
   /** Entry lists passed to zip / archives passed to unzip, in order. */
   readonly zipCalls: ZipEntry[][] = [];
   readonly unzipCalls: Uint8Array[] = [];
@@ -208,6 +210,11 @@ export class MockBackend implements Backend {
     const out = this.changedPaths;
     this.changedPaths = [];
     return out;
+  }
+
+  setWatchedRoms(paths: string[]): void {
+    this.log.push("setWatchedRoms");
+    this.watchedRoms = [...paths];
   }
 
   readFilePrefix(path: string, length: number): Uint8Array | null {

--- a/spec/00-overview.md
+++ b/spec/00-overview.md
@@ -140,7 +140,7 @@ the audio thread) — never shared. All of this is specified in
 | [04-roles-dsp-kernel.md](04-roles-dsp-kernel.md) | The role model: system-role vs feature-role, the role registry, and the DSP kernel's per-system pipelines and byte-sink ABI. |
 | [05-data-persistence.md](05-data-persistence.md) | The project model + `.rplg`, DPF get/setState + autoload, config models, forward-tolerant reads + version stamps, the LSDj sav codec, SRAM auto-save. |
 | [06-build-test.md](06-build-test.md) | How the project builds, the pnpm scripts, the dpf.js seam, and the headless verification loop. |
-| [07-remaining-work.md](07-remaining-work.md) | The remaining feature gaps now the port is complete: the file-watcher half, the raw LSDj Keyboard mode, NES per-mapper expansion sub-channels, the kit-patch UI rework, and the deferred items. |
+| [07-remaining-work.md](07-remaining-work.md) | The remaining feature gaps now the port is complete: the raw LSDj Keyboard mode, NES per-mapper expansion sub-channels, the kit-patch UI rework, and the deferred items. |
 
 ## Key files
 

--- a/spec/02-native-host.md
+++ b/spec/02-native-host.md
@@ -95,7 +95,8 @@ see [05-data-persistence.md](05-data-persistence.md).)
 | `writeFileAtomic` | `(string, Bytestring) → bool` | tmp + rename ([`:94`](../packages/native/src/host/rpc/HostRpcService.cpp#L94)) |
 | `fileExists` / `rename` / `deleteFile` | `→ bool` | |
 | `listDir` | `(string dir) → vector<string>` | filenames only |
-| `drainChangedPaths` | `→ vector<string>` | **always empty** — no file watcher in this host ([`:133`](../packages/native/src/host/rpc/HostRpcService.cpp#L133)) |
+| `drainChangedPaths` | `→ vector<string>` | pull-drain of the efsw watcher (`NativeFileWatcher`); empty until a host calls `enableWatching` (the plugin does; this test host / CLI don't) ([`:155`](../packages/native/src/host/rpc/HostRpcService.cpp#L155)) |
+| `setWatchedRoms` | `(vector<string>) → bool` | register the ROM files to watch (parent dirs); recomputed by TS on every systems-list change. Config dir + `bindings/` are always watched |
 | `canonicalize` | `(string) → string` | `weakly_canonical`, falls back to input |
 | `configDir` | `→ string` | per-OS config path, computed in this TU (no config-persistence link) ([`:23`](../packages/native/src/host/rpc/HostRpcService.cpp#L23)) |
 | `zip` | `(vector<BackendZipInput>) → Bytestring` | miniz, no-copy add ([`:147`](../packages/native/src/host/rpc/HostRpcService.cpp#L147)) |

--- a/spec/03-ts-layer.md
+++ b/spec/03-ts-layer.md
@@ -43,7 +43,7 @@ The methods, grouped by concern:
 
 | Group | Methods | What native does |
 |---|---|---|
-| **Filesystem** | `readFile` · `writeFile` · `writeFileAtomic` · `fileExists` · `rename` · `listDir` · `deleteFile` · `drainChangedPaths` | `std::filesystem` bytes; atomic temp+rename; a generic non-recursive readdir; the pull-drain of the native file watcher |
+| **Filesystem** | `readFile` · `writeFile` · `writeFileAtomic` · `fileExists` · `rename` · `listDir` · `deleteFile` · `drainChangedPaths` · `setWatchedRoms` | `std::filesystem` bytes; atomic temp+rename; a generic non-recursive readdir; the pull-drain of the native efsw file watcher + the ROM-set registration that feeds it |
 | **Paths** | `canonicalize` · `readFilePrefix` · `configDir` | `weakly_canonical` (the dedupe key); a header-only prefix read (ROM sniff without marshalling MBs); the per-OS config dir |
 | **Emulator lifecycle** | `constructSystem(spec, id)` · `removeSystem(id)` | Build/activate a core under a **TS-allocated id**; drop one. No `duplicate`/`reload` primitive — those are TS orchestration |
 | **File dialog** | `openFileBrowser(opts)` → `Promise` | Open the OS browser, resolve the picked path (the one async method) |
@@ -223,11 +223,14 @@ are validated by `isValidProfileName`
   Promise"*, no pending-mode latch. `SelectionOutcome` = `loaded | added | deferred | error
   | cancelled`.
 - **FileWatcher** — [`src/fileWatcher.ts`](../packages/retroplug/src/fileWatcher.ts):
-  the TS reaction to native's watchers. **"Watcher = C++, policy = TS."** `pump()` drains
+  the TS reaction to native's watcher. **"Watcher = C++, policy = TS."** `pump()` drains
   `backend.drainChangedPaths()` at idle and routes each: `config.json` → `userConfig.reload()`,
   `bindings/*.json` → a refresh signal, a system's ROM → `reloadSystem(id)` **when
-  `reloadOnRomChange` is on**. Native owns the efsw + mtime watching; TS owns what a change
-  *means*.
+  `reloadOnRomChange` is on**. Native (`NativeFileWatcher`, efsw) owns the watching — the config dir +
+  `bindings/` recursively, plus each ROM's parent dir (registered via `setWatchedRoms`, recomputed on
+  every systems change); TS owns what a change *means*. The plugin composes it in
+  [`pluginControlPlane.ts`](../packages/retroplug/src/pluginControlPlane.ts) and drives `pump()` from the
+  UI idle loop (`__rp_pumpWatcher`).
 - **SramAutoSaver** — [`src/sramAutoSave.ts`](../packages/retroplug/src/sramAutoSave.ts):
   the loose-`.sav` mirror policy over `backend.readSram(id)` + `resolveSavPath`, gated on the
   `sramAutoSave` preference. `flushOnSave()` writes at save/quit; `pump()` is the Continuous

--- a/spec/07-remaining-work.md
+++ b/spec/07-remaining-work.md
@@ -13,19 +13,6 @@ The runtime architecture is [01-architecture.md](01-architecture.md); nothing be
 
 Things a user could reasonably expect that aren't wired yet. None block shipping.
 
-### Native file watcher — ROM hot-reload / config live-reload is inert
-
-The design is "watcher = C++, policy = TS": native watches the config dir + `bindings/` and per-ROM
-mtimes and reports changed paths through `HostRpcService::drainChangedPaths()`; TS
-([fileWatcher.ts](../packages/retroplug/src/fileWatcher.ts) `FileWatcher.pump`) drains at idle and
-reloads systems whose ROM changed with `reloadOnRomChange` on. The **TS policy half is built +
-unit-tested**, but the **native half is a stub** — `drainChangedPaths()` returns `{}`
-([HostRpcService.cpp:155](../packages/native/src/host/rpc/HostRpcService.cpp#L155)), and the host
-links no watcher. So the "Reload on ROM Change" menu item stores/applies its preference but nothing
-triggers the reload. Closing it means adding a per-ROM mtime poll (and/or `deps/efsw` over the config
-dir) behind `drainChangedPaths`, then confirming `FileWatcher.pump` is driven from the plugin idle
-loop. (`deps/efsw` is vendored and kept for exactly this — it is not linked today.)
-
 ### Raw LSDj Keyboard mode (LsdjSyncMode 4)
 
 `lsdj-sync` implements every sync mode except raw **Keyboard**: MidiSync, MidiSyncArduinoboy,

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,8 +19,8 @@ The port is complete. RetroPlug is a single build: the older **legacy** build (t
 `Plugin*.cpp` DSP/UI, `packages/ui/`, `packages/cli/`, and the old generated RPC client) has been
 deleted, the transitional target suffix dropped, and the plugin identity reverted to the canonical
 `RetroPlug` strings. These docs describe that build in the present tense. What remains is
-**feature work, not migration** — a handful of gaps (the native file-watcher half, the raw LSDj
-Keyboard mode, NES per-mapper expansion sub-channels, the kit-patch UI rework) tracked in
+**feature work, not migration** — a handful of gaps (the raw LSDj Keyboard mode, NES per-mapper
+expansion sub-channels, the kit-patch UI rework) tracked in
 [07-remaining-work.md](07-remaining-work.md).
 
 ## The documents
@@ -34,7 +34,7 @@ Keyboard mode, NES per-mapper expansion sub-channels, the kit-patch UI rework) t
 | [04-roles-dsp-kernel.md](04-roles-dsp-kernel.md) | The role model (system-role vs feature-role) and the DSP role kernel: the byte-sink ABI, the drift-exact PPQ clock in JS, and store→kernel projection. |
 | [05-data-persistence.md](05-data-persistence.md) | The project model and `.rplg` (thin vs export), DPF get/setState, the config schemas, the forward-tolerant-read + version-stamp policy, the LSDj sav codec, and SRAM auto-save. |
 | [06-build-test.md](06-build-test.md) | How the build works, the pnpm scripts, and the headless verification loop — which command proves which kind of change. The practical "how do I verify a change" doc. |
-| [07-remaining-work.md](07-remaining-work.md) | The remaining feature gaps now the port is complete: the native file-watcher half, the raw LSDj Keyboard mode, NES per-mapper expansion sub-channels, the kit-patch UI rework, the deferred items, and the code-comment cleanup follow-up. |
+| [07-remaining-work.md](07-remaining-work.md) | The remaining feature gaps now the port is complete: the raw LSDj Keyboard mode, NES per-mapper expansion sub-channels, the kit-patch UI rework, the deferred items, and the code-comment cleanup follow-up. |
 | [08-profiling.md](08-profiling.md) | **Built** (behind `RETROPLUG_PROFILE`, `pnpm profile`). A benchmark harness that profiles the DSP-thread JS runtime — allocations/GC — under an mGB + heavy-MIDI workload: the refcount-churn reframe, the off-RT `renderAudio` harness, in-process QuickJS allocator instrumentation, the agent-friendly tool tier, and CI gates. |
 | [09-cli-debugging.md](09-cli-debugging.md) | **Built** (the plumbing tier). The CLI as a scriptable ROM-test harness: the session runner + `Timeline` + WAV/screenshot output, the compiled-in `render` subcommand, and Mesen's compiled-in debugger (decoded APU/PPU state, CPU/memory peeks + poke, breakpoints, trace, profiler, cc65 labels) surfaced through the debug RPC facet so an agent can drive a real NES and assert on its state. |
 | [10-multichannel-audio-out.md](10-multichannel-audio-out.md) | **Built** (steps 1–6; per-mapper NES expansion sub-channels remain). Outputting the individual console sound channels of one instance: Game Boy → 8 outputs (a stereo pair per channel, via a tracked SameBoy tap), NES → 5 mono stems or the hardware "stereo-mod" pins (via a `NesSoundMixer` edit). One router/mode-driven host seam (`channelLayout()` + a lane-counted `finishBlock`), a GB-scoped `AudioRouting::ChannelSplit` plugin option, and a `renderAudioPerChannel` CLI RPC feeding multichannel / per-stereo / per-mono WAV export. |


### PR DESCRIPTION
## Summary

Closes the spec/07 "native file watcher is inert" gap. The design was **"watcher = C++, policy = TS"**, but only the TS half existed: [`FileWatcher.pump`](packages/retroplug/src/fileWatcher.ts) (routing config / bindings / ROM changes to reloads) was built + unit-tested, while native `drainChangedPaths()` returned `{}`, nothing drove the pump, and `deps/efsw` wasn't even linked. So **"Reload on ROM Change" stored its preference but never fired**.

## What's new

**Native mechanism** (efsw, directory watches only — no mtime poll):
- `NativeFileWatcher` owns an `efsw::FileWatcher`: a recursive watch on the config dir covers `config.json` + `bindings/*.json`; each ROM is covered by watching its **parent dir** and filtering events to the registered basename (efsw watches dirs, not files). Any action counts as a change (handles save-by-rename). One `std::mutex` guards the changed-paths buffer + the watched-ROM filter set (efsw callback thread vs UI drain thread).
- `HostRpcService` gains opt-in `enableWatching(configDir)` + `setWatchedRoms(paths)`; `drainChangedPaths` delegates. **Stateless/thread-free until enabled**, so the test host + CLI keep the old inert behaviour — only the plugin enables it.
- efsw is `add_subdirectory`'d `EXCLUDE_FROM_ALL` and `efsw-static` linked into `retroplug-backend` (+ `Threads`, which efsw's own CMake omits for its static lib).

**Plugin wiring:**
- `PluginDSP` enables watching after the control plane boots.
- `pluginControlPlane.ts` composes a `FileWatcher` over the store graph, recomputes `setWatchedRoms` on every systems change, and exposes `__rp_pumpWatcher`.
- `PluginUI::uiIdle` drives the pump throttled (~few Hz; efsw already coalesced).

**TS backend:** `setWatchedRoms` added to `Backend`/`HostBackend`, `realBackend`, `MockBackend`.

## Verification

- **New `retroplug-watcher-test`** (Catch2, in `pnpm test:plugin`): efsw detection + ROM registration/filtering + the `HostRpcService` facade.
- Existing `FileWatcher.pump` suite, `pnpm typecheck`, and a full build of every plugin variant — green.
- **End-to-end GUI proof:** autoloaded a project whose GB system loads an on-disk ROM (`reloadOnRomChange` on), overwrote the `.gb` on disk → the running screen switched live from **mGB v.1.3.3** to the **LSDj boot screen**.
- **TSAN** caught + I fixed a teardown use-after-free (the efsw thread was joined only after the mutex/buffers it touches were gone → reordered `watcher_` to destroy first). The remaining race is efsw-internal and benign — narrowly suppressed in `tsan.supp`.

## Notes / limitations

- The pump runs while a UI exists (standalone always; a DAW plugin with its editor closed defers reload to reopen). Matches the spec's "driven from the plugin idle loop".
- Docs updated: spec/00, 02, 03, 07, README, AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)